### PR TITLE
Use less wording to prevent wrapping, which pushes buttons out of header

### DIFF
--- a/js/id/renderer/telenav_layer.js
+++ b/js/id/renderer/telenav_layer.js
@@ -1541,7 +1541,7 @@ iD.TelenavLayer = function (context) {
 
             userWindowHeader.append('h3')
                 .attr('class', 'main-header')
-                .text('Improve OSM panel');
+                .text('Improve OSM');
             var backDeselectWrapper = userWindowHeader.append('div')
                 .attr('class', 'button-wrap single joined fr')
             backDeselectWrapper.append('button')
@@ -1641,7 +1641,7 @@ iD.TelenavLayer = function (context) {
 
             generalWindowsWindowHeader.append('h3')
                 .attr('class', 'main-header')
-                .text('Improve OSM panel');
+                .text('Improve OSM');
             var switchWrapper = generalWindowsWindowHeader.append('div')
                 .attr('class', 'button-wrap joined fr')
             switchWrapper.append('button')


### PR DESCRIPTION
#8 
![image](https://cloud.githubusercontent.com/assets/365751/20413340/558de35e-ad7c-11e6-9d17-26fca3155416.png)

Its not really a 100% fix, it would probably be better to lock the header into a table-cell like layout (text and buttons each have 50% of the avail space)