### PR TITLE
Improve wrap different buttons

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -933,7 +933,7 @@ label .form-label-button-wrap .input {
 .typeForm > div {
     margin-left: 5px;
 }
-.pane-telenav.hidden {
+.pane-telenav .hidden {
     display: none;
 }
 /*#sidebar.telenavPaneActive {

--- a/css/app.css
+++ b/css/app.css
@@ -714,9 +714,6 @@ button.save.has-count .count::before {
     border-radius: 4px 4px 4px 4px;
 }
 
-/*.pane-telenav .header .telenav-header-button:focus {*/
-    /*background: none;*/
-/*}*/
 .pane-telenav .header .telenav-header-button {
     border-radius: 0px;
     min-width: 75px;
@@ -735,15 +732,7 @@ button.save.has-count .count::before {
     font-size: 14px;
 
 }
-.pane-telenav .header .telenav-header-button.active.selected{
-    background: #8ad258;
-}
-.pane-telenav .header .telenav-header-button.inactive.selected {
-    background: #e26d5b;
-}
-.pane-telenav .header .telenav-header-button.selected span {
-    color: white;
-}
+
 .pane-telenav label .form-label-button-wrap .input {
     min-width: 25px;
     padding: 5px 0;

--- a/css/app.css
+++ b/css/app.css
@@ -704,13 +704,7 @@ button.save.has-count .count::before {
     margin: 10px 0;
     height: calc(100% - 20px);
 }
-.pane-telenav .header .button-wrap button:first-child {
-    border-radius: 4px 0 0 4px;
-}
-.pane-telenav .header .button-wrap button:last-child {
-    border-radius: 0 4px 4px 0;
-}
-.pane-telenav .header .button-wrap.single button:last-child {
+.pane-telenav .header .button-wrap.single button {
     border-radius: 4px 4px 4px 4px;
 }
 

--- a/js/id/renderer/telenav_layer.js
+++ b/js/id/renderer/telenav_layer.js
@@ -1643,13 +1643,14 @@ iD.TelenavLayer = function (context) {
                 .attr('class', 'main-header')
                 .text('Improve OSM');
             var switchWrapper = generalWindowsWindowHeader.append('div')
-                .attr('class', 'button-wrap joined fr')
+                .attr('class', 'button-wrap single joined fr')
             switchWrapper.append('button')
                 .attr('class', 'telenav-header-button active hidden')
                 .attr('id', 'telenav-active')
                 .append('span')
                 .text('Activate');
             switchWrapper.append('button')
+                .attr('class', 'fr preset-close')
                 .attr('id', 'telenav-inactive')
                 .call(iD.svg.Icon('#icon-close'));
             var generalSettingsBody = generalSettingsWindow.append('div')

--- a/js/id/renderer/telenav_layer.js
+++ b/js/id/renderer/telenav_layer.js
@@ -1648,9 +1648,8 @@ iD.TelenavLayer = function (context) {
                 .attr('class', 'telenav-header-button active hidden')
                 .attr('id', 'telenav-active')
                 .append('span')
-                .text('Active');
+                .text('Activate');
             switchWrapper.append('button')
-                // .attr('class', 'fr preset-close')
                 .attr('id', 'telenav-inactive')
                 .call(iD.svg.Icon('#icon-close'));
             var generalSettingsBody = generalSettingsWindow.append('div')

--- a/js/id/renderer/telenav_layer.js
+++ b/js/id/renderer/telenav_layer.js
@@ -1541,7 +1541,7 @@ iD.TelenavLayer = function (context) {
 
             userWindowHeader.append('h3')
                 .attr('class', 'main-header')
-                .text('Improve OSM panel');
+                .text('Improve OSM');
             var backDeselectWrapper = userWindowHeader.append('div')
                 .attr('class', 'button-wrap single joined fr')
             backDeselectWrapper.append('button')
@@ -1641,7 +1641,7 @@ iD.TelenavLayer = function (context) {
 
             generalWindowsWindowHeader.append('h3')
                 .attr('class', 'main-header')
-                .text('Improve OSM panel');
+                .text('Improve OSM');
             var switchWrapper = generalWindowsWindowHeader.append('div')
                 .attr('class', 'button-wrap joined fr')
             switchWrapper.append('button')

--- a/js/id/renderer/telenav_layer.js
+++ b/js/id/renderer/telenav_layer.js
@@ -1415,8 +1415,8 @@ iD.TelenavLayer = function (context) {
                 d3.select('#telenav_waterMr').classed('editMode', true);
                 d3.select('#telenav_pathMr').classed('editMode', true);
 
-                d3.select('#telenav-active').classed('selected', true);
-                d3.select('#telenav-inactive').classed('selected', false);
+                d3.select('#telenav-active').classed('hidden', true);
+                d3.select('#telenav-inactive').classed('hidden', false);
                 d3.select('.layer-telenav').classed('editMode', true);
 
             } else {
@@ -1426,8 +1426,8 @@ iD.TelenavLayer = function (context) {
                 d3.select('#telenav_waterMr').classed('editMode', false);
                 d3.select('#telenav_pathMr').classed('editMode', false);
 
-                d3.select('#telenav-active').classed('selected', false);
-                d3.select('#telenav-inactive').classed('selected', true);
+                d3.select('#telenav-active').classed('hidden', false);
+                d3.select('#telenav-inactive').classed('hidden', true);
                 d3.select('.layer-telenav').classed('editMode', false);
 
             }
@@ -1645,15 +1645,14 @@ iD.TelenavLayer = function (context) {
             var switchWrapper = generalWindowsWindowHeader.append('div')
                 .attr('class', 'button-wrap joined fr')
             switchWrapper.append('button')
-                .attr('class', 'telenav-header-button active selected')
+                .attr('class', 'telenav-header-button active hidden')
                 .attr('id', 'telenav-active')
                 .append('span')
                 .text('Active');
             switchWrapper.append('button')
-                .attr('class', 'telenav-header-button inactive')
+                // .attr('class', 'fr preset-close')
                 .attr('id', 'telenav-inactive')
-                .append('span')
-                .text('Inactive');
+                .call(iD.svg.Icon('#icon-close'));
             var generalSettingsBody = generalSettingsWindow.append('div')
                 .attr('class', 'telenav-body');
 


### PR DESCRIPTION
A slightly fuller fix for the wrapping issue in #8 ; which swaps to the ID style buttons.

Instead of a joined button toggle, there's now an svg close icon (id style) and an activate button.